### PR TITLE
Remove update config for Solr

### DIFF
--- a/contrib/docker-ckan/docker-compose.yml
+++ b/contrib/docker-ckan/docker-compose.yml
@@ -75,9 +75,6 @@ services:
           limits:
             cpus: '2'
             memory: 4GB
-      update_config:
-        x-aws-min_percent: 50
-        x-aws-max_percent: 200
     networks:
       - ckan-internal
     # restart: unless-stopped


### PR DESCRIPTION
Solr does not behave well with rolling updates due to file lock mechanism. However, if we set up from the update_config property a min 0 and max 100, compose cli ecs integration will not correctly translate it into the generated CF template, and upon deployment of the template you'll get an error stating both min and max percent cannot be 100. Because compose cli will omit the property that has a value of 0 and will rely on the default value for it, which is 100.

Thus, this needs to be configured manually after deployment.
