### PR TITLE
Revert to classic DP until DP+ releases new verison

### DIFF
--- a/contrib/docker-ckan/base/setup/start_ckan.sh
+++ b/contrib/docker-ckan/base/setup/start_ckan.sh
@@ -55,8 +55,8 @@ UWSGI_OPTS="--plugins http,python \
 echo "Enabling ckan tracking"
 ckan config-tool $CKAN_INI "ckan.tracking_enabled = true"
 
-echo "Loading Datapusher+ settings into ckan.ini"
-ckan config-tool $CKAN_INI "ckan.datapusher.formats = csv xls xlsx xlsm xlsb tsv tab application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet ods application/vnd.oasis.opendocument.spreadsheet"
+# echo "Loading Datapusher+ settings into ckan.ini"
+# ckan config-tool $CKAN_INI "ckan.datapusher.formats = csv xls xlsx xlsm xlsb tsv tab application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet ods application/vnd.oasis.opendocument.spreadsheet"
 
 echo "Loading default views into ckan.ini"
 ckan config-tool $CKAN_INI "ckan.views.default_views = image_view text_view recline_view pdf_view"

--- a/contrib/docker-ckan/dev-base/setup/start_ckan_development.sh
+++ b/contrib/docker-ckan/dev-base/setup/start_ckan_development.sh
@@ -67,8 +67,8 @@ ckan config-tool $CKAN_INI "who.timeout = $CKAN_SESSION_TIMEOUT"
 echo "Loading the following plugins: $CKAN__PLUGINS"
 ckan config-tool $CKAN_INI "ckan.plugins = $CKAN__PLUGINS"
 
-echo "Loading Datapusher+ settings into ckan.ini"
-ckan config-tool $CKAN_INI "ckan.datapusher.formats = csv xls xlsx xlsm xlsb tsv tab application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet ods application/vnd.oasis.opendocument.spreadsheet"
+# echo "Loading Datapusher+ settings into ckan.ini"
+# ckan config-tool $CKAN_INI "ckan.datapusher.formats = csv xls xlsx xlsm xlsb tsv tab application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet ods application/vnd.oasis.opendocument.spreadsheet"
 
 echo "Loading default views into ckan.ini"
 ckan config-tool $CKAN_INI "ckan.views.default_views = image_view text_view recline_view pdf_view"

--- a/contrib/docker-ckan/docker-compose.dev.yml
+++ b/contrib/docker-ckan/docker-compose.dev.yml
@@ -36,7 +36,7 @@ services:
     
   datapusher:
     container_name: ${DATAPUSHER_CONTAINER_NAME}
-    image: ${INTERNAL_REG}/mdepckan/ckan-datapusher:latest
+    image: ckan/ckan-base-datapusher:${DATAPUSHER_VERSION}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8800"]

--- a/contrib/docker-ckan/docker-compose.yml
+++ b/contrib/docker-ckan/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     
   datapusher:
     container_name: ${DATAPUSHER_CONTAINER_NAME}
-    image: ${INTERNAL_REG}/mdepckan/ckan-datapusher:latest
+    image: ckan/ckan-base-datapusher:${DATAPUSHER_VERSION}
     deploy:
       update_config:
         x-aws-min_percent: 50


### PR DESCRIPTION
There is a critical feature missing from DP+ currently, which prevents us from using it, as it would cause too much latency and overhead. It missed the ability to use CKAN's callback URL and strictly relies on CKAN's site URL, which in our case prevents direct comm between ckan and DP+. We need to revert to classic DP until DP+ releases a new version as the callback URL has already been implemented in their codebase.