### PR TITLE
Fix privatedatasets fail to update template

### DIFF
--- a/contrib/docker-ckan/dev.env.template
+++ b/contrib/docker-ckan/dev.env.template
@@ -70,7 +70,7 @@ NGINX_SSLPORT=443
 
 # Extensions
 # Extensions
-CKAN__PLUGINS="envvars image_view text_view recline_view pdf_view datastore datapusher sso saml2auth falkor smdh taglist privatedatasets usertracking granularvisibility generalpublic"
+CKAN__PLUGINS="envvars image_view text_view recline_view pdf_view datastore datapusher sso saml2auth falkor smdh taglist usertracking granularvisibility generalpublic privatedatasets"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379

--- a/contrib/docker-ckan/prod.env.template
+++ b/contrib/docker-ckan/prod.env.template
@@ -74,7 +74,7 @@ NGINX_PORT=80
 NGINX_SSLPORT=443
 
 # Extensions
-CKAN__PLUGINS="envvars image_view text_view datatables_view pdf_view datastore datapusher sso saml2auth falkor smdh usertracking taglist privatedatasets granularvisibility generalpublic"
+CKAN__PLUGINS="envvars image_view text_view datatables_view pdf_view datastore datapusher sso saml2auth falkor smdh usertracking taglist granularvisibility generalpublic privatedatasets"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379


### PR DESCRIPTION
Fix granularvisibility plugin dependency interaction causing it to fail to properly update templates.

This issue only surfaced now because before the plugin name was fixed, ckan always moved it to the end of the list as it has a different name from the config name.