### PR TITLE
Updated plugins list in settings file

### DIFF
--- a/contrib/docker-ckan/dev.env.template
+++ b/contrib/docker-ckan/dev.env.template
@@ -76,7 +76,8 @@ NGINX_SSLPORT=443
 
 # Extensions
 # Keep the datasetformchain plugin at the end as it depends on the order to function correctly
-CKAN__PLUGINS="envvars datasci_sharing image_view text_view recline_view pdf_view cloudstorage datastore datapusher sso saml2auth smdh smdh_dataset_form smdh_group_form taglist usertracking granularvisibility generalpublic privatedatasets datasetformchain"
+# 'smdh' plugin is moved to the second last position because some of the overriding templates in ckanext-smdh are not using the ckan_extends.
+CKAN__PLUGINS="envvars datasci_sharing image_view text_view recline_view pdf_view cloudstorage datastore datapusher sso saml2auth smdh_dataset_form smdh_group_form taglist usertracking granularvisibility generalpublic privatedatasets smdh datasetformchain"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379

--- a/contrib/docker-ckan/prod.env.template
+++ b/contrib/docker-ckan/prod.env.template
@@ -83,7 +83,8 @@ NGINX_SSLPORT=443
 
 # Extensions
 # Keep the datasetformchain plugin at the end as it depends on the order to function correctly
-CKAN__PLUGINS="envvars datasci_sharing image_view text_view datatables_view pdf_view cloudstorage datastore datapusher sso saml2auth smdh smdh_dataset_form smdh_group_form usertracking taglist granularvisibility generalpublic privatedatasets datasetformchain"
+# 'smdh' plugin is moved to the second last position because some of the overriding templates in ckanext-smdh are not using the ckan_extends.
+CKAN__PLUGINS="envvars datasci_sharing image_view text_view datatables_view pdf_view cloudstorage datastore datapusher sso saml2auth smdh_dataset_form smdh_group_form usertracking taglist granularvisibility generalpublic privatedatasets smdh datasetformchain"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379


### PR DESCRIPTION
Fixes #

### Proposed fixes:

In the settings file, 'smdh' plugin is moved to the second last position because some of the overriding templates in ckanext-smdh are not using the ckan_extends.
This is because template extension is co-operative and relies on each plugin having the tag ckan_extends. 
### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ x] includes bugfix for possible backport

Please [X] all the boxes above that apply
